### PR TITLE
Add a flag to explicitly state the torchserve model_store location

### DIFF
--- a/Lab1_Operationalizing_Pytorch_with_Mlflow/src/bert-classifier/entrypoints/torchserve.sh
+++ b/Lab1_Operationalizing_Pytorch_with_Mlflow/src/bert-classifier/entrypoints/torchserve.sh
@@ -7,4 +7,5 @@ mlflow deployments create \
         -m models:${MODEL_NAME} \
         --name news_classification \
         -C "MODEL_FILE=news_classifier.py" \
-        -C "HANDLER=news_classifier_handler.py"
+        -C "HANDLER=news_classifier_handler.py"\
+        -C "EXPORT_PATH=/opt/mlflow/model_store"


### PR DESCRIPTION
I think since the entrypoint file lives in `/opt/mlflow/scripts`, it's looking for the model_store in that directory instead of where it actually is. 

I diffed all the files inside the "good" image with the ones we're building now and spotted this change I had made. Added this and now deployments work fine.
I _think_ what happened was the `requirements.txt` changes solved the original int/bytes problem, however this problem remained.

