### PR TITLE
Run training from master only

### DIFF
--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -86,7 +86,7 @@ jobs:
           MLFLOW_TRACKING_URI: http://35.185.111.8:5000
         with:
           args: |
-            compute ssh --zone us-east1-b compute-1 -- "bash /root/train.sh ${MLFLOW_TRACKING_URI} master ${GITHUB_SHA}
+            compute ssh --zone us-east1-b compute-1 -- "bash /root/train.sh ${MLFLOW_TRACKING_URI} ${GITHUB_SHA}
       - name: Stop training node
         uses: actions-hub/gcloud@master
         if: ${{ always() }}

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -1,10 +1,8 @@
 name: "Run training"
 
-# Trigger the workflow on push for the master branch and on any PR
 on:
   push:
     branches: [master]
-  pull_request:
 
 jobs:
   train:
@@ -86,7 +84,7 @@ jobs:
           MLFLOW_TRACKING_URI: http://35.185.111.8:5000
         with:
           args: |
-            compute ssh --zone us-east1-b compute-1 -- "bash /root/train.sh ${MLFLOW_TRACKING_URI} ${GITHUB_SHA}
+            compute ssh --zone us-east1-b compute-1 -- "bash -x /root/train.sh ${MLFLOW_TRACKING_URI} ${GITHUB_SHA}
       - name: Stop training node
         uses: actions-hub/gcloud@master
         if: ${{ always() }}

--- a/Lab1_Operationalizing_Pytorch_with_Mlflow/src/bert-classifier/train.sh
+++ b/Lab1_Operationalizing_Pytorch_with_Mlflow/src/bert-classifier/train.sh
@@ -3,13 +3,13 @@ set -euo pipefail
 IFS=$'\n\t'
 
 clone() {
-    BRANCH="$1"
+    SHA="$1"
 
     TMPDIR=$(mktemp -d /tmp/model.XXXXXXXXXX)
     cd "$TMPDIR"
     git clone https://github.com/mlops-labs-team1/engineering.labs.git
     cd engineering.labs/Lab1_Operationalizing_Pytorch_with_Mlflow/src/bert-classifier/
-    git checkout "$BRANCH"
+    git checkout "$SHA"
 }
 
 export_model_version() {
@@ -37,11 +37,10 @@ train() {
 
 main() {
     export MLFLOW_TRACKING_URI="$1"
-    BRANCH="$2"
-    TAG="$3"
+    SHA="$2"
 
-    clone "$BRANCH"
-    train "$TAG"
+    clone "$SHA"
+    train "$SHA"
 }
 
 main "$@"

--- a/Lab1_Operationalizing_Pytorch_with_Mlflow/src/bert-classifier/train.sh
+++ b/Lab1_Operationalizing_Pytorch_with_Mlflow/src/bert-classifier/train.sh
@@ -3,13 +3,10 @@ set -euo pipefail
 IFS=$'\n\t'
 
 clone() {
-    SHA="$1"
-
     TMPDIR=$(mktemp -d /tmp/model.XXXXXXXXXX)
     cd "$TMPDIR"
     git clone https://github.com/mlops-labs-team1/engineering.labs.git
     cd engineering.labs/Lab1_Operationalizing_Pytorch_with_Mlflow/src/bert-classifier/
-    git checkout "$SHA"
 }
 
 export_model_version() {
@@ -39,7 +36,7 @@ main() {
     export MLFLOW_TRACKING_URI="$1"
     SHA="$2"
 
-    clone "$SHA"
+    clone
     train "$SHA"
 }
 


### PR DESCRIPTION
~As of now we always run training from master branch, which is wrong. With this change training always happens from current (the one from pull request that triggered the workflow or from master) branch instead.~

Closes https://github.com/mlops-labs-team1/engineering.labs/issues/33